### PR TITLE
bug: move entrypoint to additional file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY pebbleMap ./
+COPY entrypoint.sh ./
 
 EXPOSE 8041
-CMD [ "waitress-serve", "--port=8041", '--url-scheme=https', "app:app" ]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+waitress-serve --port=8041 --url-scheme=https "app:app"


### PR DESCRIPTION
/bin/sh does not like a colon that is not escaped using double quotes